### PR TITLE
Fix with adding to scrapView items with viewType ITEM_VIEW_TYPE_IGNORE

### DIFF
--- a/library/src/org/lucasr/twowayview/TwoWayView.java
+++ b/library/src/org/lucasr/twowayview/TwoWayView.java
@@ -4464,7 +4464,8 @@ public class TwoWayView extends AdapterView<ListAdapter> implements
             if (mViewTypeCount == 1) {
                 mCurrentScrap.add(scrap);
             } else {
-                mScrapViews[lp.viewType].add(scrap);
+                if (lp.viewType != ITEM_VIEW_TYPE_IGNORE)
+                    mScrapViews[lp.viewType].add(scrap);
             }
 
             if (mRecyclerListener != null) {


### PR DESCRIPTION
If item viewType is ITEM_VIEW_TYPE_IGNORE then we should not add it to scrapView.

This fixed the failure of TwoWayView when trying to integrate cwac-endless adapter to it.
