### PR TITLE
Update empty view state

### DIFF
--- a/library/src/org/lucasr/twowayview/TwoWayView.java
+++ b/library/src/org/lucasr/twowayview/TwoWayView.java
@@ -211,6 +211,8 @@ public class TwoWayView extends AdapterView<ListAdapter> implements
     private OnScrollListener mOnScrollListener;
     private int mLastScrollState;
 
+    private View mEmptyView;
+
     public interface OnScrollListener {
 
         /**
@@ -774,6 +776,7 @@ public class TwoWayView extends AdapterView<ListAdapter> implements
             checkSelectionChanged();
         }
 
+        updateEmptyStatus();
         requestLayout();
     }
 
@@ -4611,6 +4614,38 @@ public class TwoWayView extends AdapterView<ListAdapter> implements
         }
     }
 
+    @Override
+    public void setEmptyView(View emptyView) {
+        super.setEmptyView(emptyView);
+        mEmptyView = emptyView;
+        updateEmptyStatus();
+    }
+
+    private void updateEmptyStatus() {
+        boolean isEmpty = mAdapter == null || mAdapter.isEmpty();
+        if (isEmpty) {
+            if (mEmptyView != null) {
+                mEmptyView.setVisibility(View.VISIBLE);
+                setVisibility(View.GONE);
+            } else {
+                // If the caller just removed our empty view, make sure the list
+                // view is visible
+                setVisibility(View.VISIBLE);
+            }
+
+            // We are now GONE, so pending layouts will not be dispatched.
+            // Force one here to make sure that the state of the list matches
+            // the state of the adapter.
+            if (mDataChanged) {
+                this.onLayout(false, getLeft(), getTop(), getRight(), getBottom());
+            }
+        } else {
+            if (mEmptyView != null)
+                mEmptyView.setVisibility(View.GONE);
+            setVisibility(View.VISIBLE);
+        }
+    }
+
     private class AdapterDataSetObserver extends DataSetObserver {
         private Parcelable mInstanceState = null;
 
@@ -4629,7 +4664,7 @@ public class TwoWayView extends AdapterView<ListAdapter> implements
             } else {
                 rememberSyncState();
             }
-
+            updateEmptyStatus();
             requestLayout();
         }
 
@@ -4655,6 +4690,7 @@ public class TwoWayView extends AdapterView<ListAdapter> implements
 
             mNeedSync = false;
 
+            updateEmptyStatus();
             requestLayout();
         }
     }


### PR DESCRIPTION
The state of the empty view needs to be updated whenever the dataset is
changed or invalidated

In AdapterView the `updateEmptyStatus()` method is called from inside `checkFocus()` which is called from `DataSetObserver.onChanged()` and `DataSetObserver.onInvalidated()`. 

ListView and GridView also call `checkFocus()` when the adapter is set. 

Neither `checkFocus()` or `updateEmptyStatus()` are accessible so we'll have to keep a reference to the empty view to update it's visibility.
