### PR TITLE
[library] Finish scroller when reseting state

### DIFF
--- a/library/src/main/java/org/lucasr/twowayview/TwoWayView.java
+++ b/library/src/main/java/org/lucasr/twowayview/TwoWayView.java
@@ -5368,6 +5368,8 @@ public class TwoWayView extends AdapterView<ListAdapter> implements
     }
 
     void resetState() {
+        mScroller.forceFinished(true);
+
         removeAllViewsInLayout();
 
         mSelectedStart = 0;


### PR DESCRIPTION
Fixes crash when adapter gets replaced/removed while performing a fling.

Steps to reproduce:
1. Use an adapter with enough items to fling for a while.
2. Replace adapter or set to `null` while performing fling.
3. Boom shakalaka

![Boom shakalaka](http://i52.tinypic.com/2d82fz7.gif)
