### PR TITLE
Fix end EdgeEffect being offset by padding

### DIFF
--- a/library/src/main/java/org/lucasr/twowayview/TwoWayView.java
+++ b/library/src/main/java/org/lucasr/twowayview/TwoWayView.java
@@ -3224,8 +3224,8 @@ public class TwoWayView extends AdapterView<ListAdapter> implements
         }
 
         final int restoreCount = canvas.save();
-        final int width = getWidth() - getPaddingLeft() - getPaddingRight();
-        final int height = getHeight() - getPaddingTop() - getPaddingBottom();
+        final int width = getWidth();
+        final int height = getHeight();
 
         if (mIsVertical) {
             canvas.translate(-width, height);


### PR DESCRIPTION
The end EdgeEffect is offset by the sum of both paddings (left+right in horizontal mode, top+bottom in vertical). This is inconsistent with standard Android API and looks ugly.

This change fixes the edge behavior in my tests.
