### PR TITLE
[library] Keep scroll position for notifyDataSetChanged in horizontal orientation

### DIFF
--- a/library/src/main/java/org/lucasr/twowayview/TwoWayView.java
+++ b/library/src/main/java/org/lucasr/twowayview/TwoWayView.java
@@ -5423,7 +5423,7 @@ public class TwoWayView extends AdapterView<ListAdapter> implements
             mSyncPosition = mFirstPosition;
 
             if (child != null) {
-                mSpecificStart = child.getTop();
+                mSpecificStart = (mIsVertical ? child.getTop() : child.getLeft());
             }
 
             mSyncMode = SYNC_FIRST_POSITION;


### PR DESCRIPTION
This pull request fixes "jump" problem after notifyDataSetChanged.
To reproduce this problem set orientation to horizontal, scroll to and invoke notifyDataSetChanged. After that view will reset position to left edge of first visible item. It's undesired behavior if you want to implement endless adapter.
