### PR TITLE
Remove call to initializeScrollbars

### DIFF
--- a/library/src/main/java/org/lucasr/twowayview/TwoWayView.java
+++ b/library/src/main/java/org/lucasr/twowayview/TwoWayView.java
@@ -385,9 +385,6 @@ public class TwoWayView extends AdapterView<ListAdapter> implements
 
         ViewCompat.setOverScrollMode(this, ViewCompat.OVER_SCROLL_IF_CONTENT_SCROLLS);
 
-        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.TwoWayView, defStyle, 0);
-        initializeScrollbars(a);
-
         mDrawSelectorOnTop = a.getBoolean(
                 R.styleable.TwoWayView_android_drawSelectorOnTop, false);
 


### PR DESCRIPTION
This call should not be necessary as it is already called by the framework. Avoid extra call to obtainStyledAttributes
