### PR TITLE
[layouts] Fixed scrolling on repaint partially drawn items

### DIFF
--- a/layouts/src/main/java/org/lucasr/twowayview/widget/BaseLayoutManager.java
+++ b/layouts/src/main/java/org/lucasr/twowayview/widget/BaseLayoutManager.java
@@ -360,7 +360,7 @@ public abstract class BaseLayoutManager extends TwoWayLayoutManager {
         final int anchorItemPosition = getAnchorItemPosition(state);
 
         // Only move layout if we're not restoring a layout state.
-        if (anchorItemPosition > 0 && (refreshingLanes || !restoringLanes)) {
+        if (anchorItemPosition > 0 && refreshingLanes && !restoringLanes) {
             moveLayoutToPosition(anchorItemPosition, getPendingScrollOffset(), recycler, state);
         }
 


### PR DESCRIPTION
Right now moveLayoutToPosition is called every time when we are not at very beginning of list/grid and not in process of restoring (`!restoringLanes` is true for most of cases). Method `onLayoutChildren` is called every time when child view asked to be relayouted (for example, ImageView assigning a picture), so if first visible item is visible partially, view forced to be scroll up/left to show it whole content.

This commit will fix issue https://github.com/lucasr/twoway-view/issues/159 and probably fix issues https://github.com/lucasr/twoway-view/issues/140 and https://github.com/lucasr/twoway-view/issues/156
