### PR TITLE
Proguard needs to be notified to keep the twowayview classes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Gradle:
 compile 'org.lucasr.twowayview:twowayview:0.1.4'
 ```
 
+If you are using ProGuard add the following line to the rules:
+```groovy
+-keep class org.lucasr.twowayview.** { *; }
+```
 
 Want to help?
 =============


### PR DESCRIPTION
I've used the previous twoway-view standalone adapterview implementation in a few projects and it saved me a LOT of time.  Thanks for an awesome library!  :+1: 
I'm starting to port things to the new one, but I had an annoying non-descript crash while trying to instantiate the LayoutManager. 

After a day of hair pulling it turns out its a silly noob issue with ProGuard deleting the twoway-view classes since I forgot to add a -keep line to the proguard-rules.

Would be great if you accept the pull request or add it to the Readme, it might save someone a lot of time :)

Keep up the good work, 

Blaz
