### PR TITLE
[sample] add image in item to show jumping bug.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.13.3+'
+        classpath 'com.android.tools.build:gradle:0.14.4'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu May 01 23:00:57 BST 2014
+#Fri Nov 28 15:38:23 CET 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -20,4 +20,5 @@ dependencies {
     compile project(':core')
     compile project(':layouts')
     compile 'com.android.support:appcompat-v7:21.0.0'
+    compile 'com.squareup.picasso:picasso:2.4.0'
 }

--- a/sample/src/main/java/org/lucasr/twowayview/sample/LayoutAdapter.java
+++ b/sample/src/main/java/org/lucasr/twowayview/sample/LayoutAdapter.java
@@ -21,12 +21,15 @@ import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageView;
 import android.widget.TextView;
 
+import com.squareup.picasso.Picasso;
+
 import org.lucasr.twowayview.TwoWayLayoutManager;
-import org.lucasr.twowayview.widget.TwoWayView;
 import org.lucasr.twowayview.widget.SpannableGridLayoutManager;
 import org.lucasr.twowayview.widget.StaggeredGridLayoutManager;
+import org.lucasr.twowayview.widget.TwoWayView;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -41,11 +44,13 @@ public class LayoutAdapter extends RecyclerView.Adapter<LayoutAdapter.SimpleView
     private int mCurrentItemId = 0;
 
     public static class SimpleViewHolder extends RecyclerView.ViewHolder {
+        public final ImageView image;
         public final TextView title;
 
         public SimpleViewHolder(View view) {
             super(view);
             title = (TextView) view.findViewById(R.id.title);
+            image = (ImageView) view.findViewById(R.id.image);
         }
     }
 
@@ -80,6 +85,10 @@ public class LayoutAdapter extends RecyclerView.Adapter<LayoutAdapter.SimpleView
     @Override
     public void onBindViewHolder(SimpleViewHolder holder, int position) {
         holder.title.setText(mItems.get(position).toString());
+        Picasso.with(holder.image.getContext().getApplicationContext())
+                .load("http://lorempixel.com/400/400/animals/" + (1 + position % 10))
+                .skipMemoryCache()
+                .into(holder.image);
 
         boolean isVertical = (mRecyclerView.getOrientation() == TwoWayLayoutManager.Orientation.VERTICAL);
         final View itemView = holder.itemView;

--- a/sample/src/main/res/layout/item.xml
+++ b/sample/src/main/res/layout/item.xml
@@ -15,12 +15,23 @@
    limitations under the License.
 -->
 
-<TextView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/title"
-    android:layout_width="70dp"
-    android:layout_height="130dp"
-    android:gravity="center"
-    android:textColor="#999999"
-    android:textStyle="bold"
-    android:textSize="22sp"
-    android:background="@drawable/item_background"/>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+             android:layout_width="70dp"
+             android:layout_height="130dp"
+             android:background="@drawable/item_background">
+
+    <ImageView
+        android:id="@+id/image"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:scaleType="centerCrop"/>
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:textColor="#999999"
+        android:textSize="22sp"
+        android:textStyle="bold" />
+</FrameLayout>


### PR DESCRIPTION
Add some images in sample to show jumping bug.
Case 1:
scroll down, and when images are loaded RecyclerView jump to the first visible position.
The bug is present in all LayoutManager.
Case 2: scroll to the top of the RecyclerView, a gap is appear between first item and RecyclerView.
The bug is present in the GridLayoutManager and the SpannableLayoutManager.

The sample illustrates now the bug trying to be fixed in the PR  #167

Enjoy animals :)

![device-2014-11-28-161355](https://cloud.githubusercontent.com/assets/3284106/5229638/041734c4-771b-11e4-8602-b6b9ce79c7bc.png)
