### PR TITLE
Guard against state.getItemCount() being < 0

### DIFF
--- a/core/src/main/java/org/lucasr/twowayview/TwoWayLayoutManager.java
+++ b/core/src/main/java/org/lucasr/twowayview/TwoWayLayoutManager.java
@@ -273,7 +273,7 @@ public abstract class TwoWayLayoutManager extends LayoutManager {
     }
 
     private void fillSpecific(int position, Recycler recycler, State state) {
-        if (state.getItemCount() == 0) {
+        if (state.getItemCount() <= 0) {
             return;
         }
 


### PR DESCRIPTION
This seems like a bug in RecyclerView but can happen if the adapter is changed multiple times between layouts.