### PR TITLE
Fixed glitching scroll offset when using image loaders

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,9 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        if(this == rootProject) {
+            classpath 'com.android.tools.build:gradle:2.3.0'
+        }
     }
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -19,4 +19,3 @@ android {
     }
 }
 
-apply from: "${rootDir}/gradle/scripts/gradle-mvn-push.gradle"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 
 android {
     compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    buildToolsVersion "25.0.2"
     resourcePrefix 'twowayview_'
 
     defaultConfig {

--- a/core/src/main/java/org/lucasr/twowayview/TwoWayLayoutManager.java
+++ b/core/src/main/java/org/lucasr/twowayview/TwoWayLayoutManager.java
@@ -479,7 +479,7 @@ public abstract class TwoWayLayoutManager extends LayoutManager {
         return child;
     }
 
-    private void handleUpdate() {
+    protected void handleUpdate() {
         // Refresh state by requesting layout without changing the
         // first visible position. This will ensure the layout will
         // sync with the adapter changes.

--- a/layouts/build.gradle
+++ b/layouts/build.gradle
@@ -20,4 +20,3 @@ dependencies {
     compile 'com.android.support:recyclerview-v7:21.0.0'
 }
 
-apply from: "${rootDir}/gradle/scripts/gradle-mvn-push.gradle"

--- a/layouts/build.gradle
+++ b/layouts/build.gradle
@@ -6,7 +6,7 @@ repositories {
 
 android {
     compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    buildToolsVersion "25.0.2"
     resourcePrefix 'twowayview_'
 
     defaultConfig {

--- a/layouts/src/main/java/org/lucasr/twowayview/widget/BaseLayoutManager.java
+++ b/layouts/src/main/java/org/lucasr/twowayview/widget/BaseLayoutManager.java
@@ -21,7 +21,6 @@ import android.graphics.Rect;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.v7.widget.RecyclerView;
-import android.support.v7.widget.RecyclerView.Adapter;
 import android.support.v7.widget.RecyclerView.LayoutParams;
 import android.support.v7.widget.RecyclerView.Recycler;
 import android.support.v7.widget.RecyclerView.State;
@@ -29,7 +28,6 @@ import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewGroup.MarginLayoutParams;
-
 import org.lucasr.twowayview.TwoWayLayoutManager;
 import org.lucasr.twowayview.widget.Lanes.LaneInfo;
 
@@ -361,6 +359,7 @@ public abstract class BaseLayoutManager extends TwoWayLayoutManager {
 
         // Only move layout if we're not restoring a layout state.
         if (anchorItemPosition > 0 && (refreshingLanes || !restoringLanes)) {
+            handleUpdate();
             moveLayoutToPosition(anchorItemPosition, getPendingScrollOffset(), recycler, state);
         }
 


### PR DESCRIPTION
When using Twoway View with Picasso for async image loading, onLayoutChildren() will be called, causing the list to reset it's scroll offset.

This issue is fixed by saving the correct scroll position before calling moveLayoutToPosition() resulting in smooth scrolling without glitches.

I guess this also fixes issue #159.
