### PR TITLE
set a custom secondary cell dimension from elsewhere

### DIFF
--- a/layouts/build.gradle
+++ b/layouts/build.gradle
@@ -17,7 +17,7 @@ android {
 
 dependencies {
     compile project(':core')
-    compile 'com.android.support:recyclerview-v7:21.0.0'
+    compile 'com.android.support:recyclerview-v7:22.1.0'
 }
 
 apply from: "${rootDir}/gradle/scripts/gradle-mvn-push.gradle"

--- a/layouts/src/main/java/org/lucasr/twowayview/widget/Lanes.java
+++ b/layouts/src/main/java/org/lucasr/twowayview/widget/Lanes.java
@@ -36,6 +36,20 @@ class Lanes {
     private Integer mInnerStart;
     private Integer mInnerEnd;
 
+    private final int mSecondaryDimension;
+    
+    public int getLaneWidth() {
+        return mIsVertical || mSecondaryDimension == 0 ? mLaneSize : mSecondaryDimension;
+    }
+    
+    public int getLaneHeight() {
+        return !mIsVertical || mSecondaryDimension == 0 ? mLaneSize : mSecondaryDimension;
+    }
+    
+    public int getSecondaryDimension() {
+        return mSecondaryDimension;
+    }
+    
     public static class LaneInfo {
         public int startLane;
         public int anchorLane;
@@ -56,10 +70,17 @@ class Lanes {
     }
 
     public Lanes(BaseLayoutManager layout, Orientation orientation, Rect[] lanes, int laneSize) {
+        this(layout, orientation, lanes, laneSize, 0);
+    }
+    
+    public Lanes(BaseLayoutManager layout, Orientation orientation, Rect[] lanes, int laneSize,
+        int secondaryDimension
+    ) {
         mLayout = layout;
         mIsVertical = (orientation == Orientation.VERTICAL);
         mLanes = lanes;
         mLaneSize = laneSize;
+        mSecondaryDimension = secondaryDimension;
 
         mSavedLanes = new Rect[mLanes.length];
         for (int i = 0; i < mLanes.length; i++) {
@@ -68,6 +89,12 @@ class Lanes {
     }
 
     public Lanes(BaseLayoutManager layout, int laneCount) {
+        this(layout, laneCount, 0);
+    }
+    
+    public Lanes(BaseLayoutManager layout, int laneCount,
+        int secondaryDimension
+    ) {
         mLayout = layout;
         mIsVertical = layout.isVertical();
 
@@ -79,6 +106,7 @@ class Lanes {
         }
 
         mLaneSize = calculateLaneSize(layout, laneCount);
+        mSecondaryDimension = secondaryDimension;
 
         final int paddingLeft = layout.getPaddingLeft();
         final int paddingTop = layout.getPaddingTop();

--- a/layouts/src/main/java/org/lucasr/twowayview/widget/SpannableGridLayoutManager.java
+++ b/layouts/src/main/java/org/lucasr/twowayview/widget/SpannableGridLayoutManager.java
@@ -92,11 +92,11 @@ public class SpannableGridLayoutManager extends GridLayoutManager {
     }
 
     private int getChildWidth(int colSpan) {
-        return getLanes().getLaneSize() * colSpan;
+        return getLanes().getLaneWidth() * colSpan;
     }
 
     private int getChildHeight(int rowSpan) {
-        return getLanes().getLaneSize() * rowSpan;
+        return getLanes().getLaneHeight() * rowSpan;
     }
 
     private static int getLaneSpan(LayoutParams lp, boolean isVertical) {

--- a/sample/src/main/java/org/lucasr/twowayview/sample/LayoutFragment.java
+++ b/sample/src/main/java/org/lucasr/twowayview/sample/LayoutFragment.java
@@ -17,6 +17,7 @@
 package org.lucasr.twowayview.sample;
 
 import android.app.Activity;
+import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
@@ -35,6 +36,7 @@ import static android.support.v7.widget.RecyclerView.SCROLL_STATE_SETTLING;
 import org.lucasr.twowayview.ItemClickSupport;
 import org.lucasr.twowayview.ItemClickSupport.OnItemClickListener;
 import org.lucasr.twowayview.ItemClickSupport.OnItemLongClickListener;
+import org.lucasr.twowayview.widget.BaseLayoutManager;
 import org.lucasr.twowayview.widget.DividerItemDecoration;
 import org.lucasr.twowayview.widget.TwoWayView;
 
@@ -84,6 +86,14 @@ public class LayoutFragment extends Fragment {
         mRecyclerView.setHasFixedSize(true);
         mRecyclerView.setLongClickable(true);
 
+        RecyclerView.LayoutManager layoutManager = mRecyclerView.getLayoutManager();
+        Resources res = getResources();
+        if (layoutManager instanceof BaseLayoutManager) {
+            BaseLayoutManager manager = (BaseLayoutManager) layoutManager;
+            manager.setCustomWidth((int) res.getDimension(R.dimen.abc_text_size_display_2_material));
+            manager.setCustomHeight((int) res.getDimension(R.dimen.abc_text_size_display_1_material));
+        };
+
         mPositionText = (TextView) view.getRootView().findViewById(R.id.position);
         mCountText = (TextView) view.getRootView().findViewById(R.id.count);
 
@@ -122,7 +132,7 @@ public class LayoutFragment extends Fragment {
             }
         });
 
-        final Drawable divider = getResources().getDrawable(R.drawable.divider);
+        final Drawable divider = res.getDrawable(R.drawable.divider);
         mRecyclerView.addItemDecoration(new DividerItemDecoration(divider));
 
         mRecyclerView.setAdapter(new LayoutAdapter(activity, mRecyclerView, mLayoutId));


### PR DESCRIPTION
Currently, SpannableGridLayoutManager overassumes square shape of the cells. No need to.
It is still the default in the branch, but the client can override the secondary (scrolling) dimension, e.g. specify cell width in a horizontally-scrolled view or cell height in a vertically-scrolled view.
